### PR TITLE
feat: decs 1.4.18 에서 group id 의 유무를 확인하는 로직 추가

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,14 +38,16 @@ if ! id "$USER_ID" >/dev/null 2>&1; then
 fi
 
 # 그룹 기능(여러 사용자가 동일한 폴더에 접근 가능)
-# 그룹 폴더가 없는 경우(신규 그룹) 생성
-if [ ! -d "/home/$USER_GROUP/" ]; then
-  # 폴더 생성
-  mkdir /home/$USER_GROUP
-  echo "Created /home/$USER_GROUP...."
-fi
+# 2024년 11월 2일 추가 - $USER_GROUP 환경 변수값이 있을 때만 그룹 관련 명령을 실행
+if [ -n "$USER_GROUP" ]; then
+  # 그룹 폴더가 없는 경우(신규 그룹) 생성
+  if [ ! -d "/home/$USER_GROUP/" ]; then
+    # 폴더 생성
+    mkdir /home/$USER_GROUP
+    echo "Created /home/$USER_GROUP...."
+  fi
 
-# 그룹 추가, 등록, 권한 설정
+  # 그룹 추가, 등록, 권한 설정
   groupadd $USER_GROUP
   usermod -aG $USER_GROUP $USER_ID
 
@@ -56,6 +58,7 @@ fi
   # 그룹의 공유 디렉토리의 권한 설정
   chmod g+rw /home/$USER_GROUP
   echo "Group Permission Setting done"
+fi
 
 # UID, GID 설정 (UID가 기본적으로 1001로 시작되는데, 컨테이너끼리 겹치면 접근 제한 불가)
 groupmod -g $UID $USER_ID


### PR DESCRIPTION
🚨 기존 이미지를 사용하여 사용자 통합 관리 문서에서 group id 를 작성하지 않고 컨테이너를 생성 시 오류 발생
🚨 오류 내용 : 다음 과 같은 코드가 실행 되어야 하는데, group id 가 비워져 있으면 아래와 같이 실행됨
  정상 코드 : chown -R svmanager:$USER_GROUP /home/$USER_GROUP
                   chmod -R 770 /home/$USER_GROUP
  오류 코드 : chown -R svmanager:  (공란)  /home/  (공란)
                   chmod -R 770 /home/(공란)
이 오류가 발생하면, NAS/STORAGE 의 모든 권한이 svmanager 로 변경되는 심각한 오류 발생
따라서 group id 가 존재할 때만 위 명령을 실행하도록 코드 수정