### PR TITLE
[fix] 기존 사용자의 컨테이너 변경 시 ~/.bashrc conda initialize 블록 업데이트

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,15 @@ if ! id "$USER_ID" >/dev/null 2>&1; then
     sed -i "/^#PermitRootLogin/a AllowUsers svmanager" /etc/ssh/sshd_config
     sed -i "/^#PermitRootLogin/a AllowUsers $USER_ID" /etc/ssh/sshd_config
     sed -i 's/^UsePAM yes/UsePAM no/' /etc/ssh/sshd_config
+
+else
+
+# 기존 유저 디렉토리의 /.bashrc에서 conda initialize 블록 제거
+sed -i "/# >>> conda initialize >>>/,/# <<< conda initialize <<</d" /home/$USER_ID/.bashrc
+
+# /root/.bashrc에서 conda initialize 블록 추출해서 /home/$USER_ID/.bashrc에 추가
+sed -n "/# >>> conda initialize >>>/,/# <<< conda initialize <<</p" /root/.bashrc >> /home/$USER_ID/.bashrc
+
 fi
 
 # 그룹이 존재하지 않을 경우 생성하고 사용자를 그룹에 추가

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,19 +37,19 @@ if ! id "$USER_ID" >/dev/null 2>&1; then
 
 else
 
-# 기존 유저 디렉토리의 /.bashrc에서 conda initialize 블록과 경고 주석을 제거
-sed -i \
-    -e "/# !!! Do NOT delete the conda initialize comments below\. !!!/d" \
-    -e "/# !!! Do NOT add anything inside the conda initialize block\. It will be removed on container restart\/update\. !!!/d" \
-    -e "/# >>> conda initialize >>>/,/# <<< conda initialize <<</d" \
-    /home/$USER_ID/.bashrc
+    # 기존 유저 디렉토리의 /.bashrc에서 conda initialize 블록과 경고 주석을 제거
+    sed -i \
+        -e "/# !!! Do NOT delete the conda initialize comments below\. !!!/d" \
+        -e "/# !!! Do NOT add anything inside the conda initialize block\. It will be removed on container restart\/update\. !!!/d" \
+        -e "/# >>> conda initialize >>>/,/# <<< conda initialize <<</d" \
+        /home/$USER_ID/.bashrc
 
-# /root/.bashrc에서 conda initialize 블록 추출해서 /home/$USER_ID/.bashrc에 추가
-{
-    echo "# !!! Do NOT delete the conda initialize comments below. !!!"
-    echo "# !!! Do NOT add anything inside the conda initialize block. It will be removed on container restart/update. !!!"
-    sed -n '/# >>> conda initialize >>>/,/# <<< conda initialize <<</p' /root/.bashrc
-} >> /home/$USER_ID/.bashrc
+    # /root/.bashrc에서 conda initialize 블록 추출해서 /home/$USER_ID/.bashrc에 추가
+    {
+        echo "# !!! Do NOT delete the conda initialize comments below. !!!"
+        echo "# !!! Do NOT add anything inside the conda initialize block. It will be removed on container restart/update. !!!"
+        sed -n '/# >>> conda initialize >>>/,/# <<< conda initialize <<</p' /root/.bashrc
+    } >> /home/$USER_ID/.bashrc
 
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,11 +37,19 @@ if ! id "$USER_ID" >/dev/null 2>&1; then
 
 else
 
-# 기존 유저 디렉토리의 /.bashrc에서 conda initialize 블록 제거
-sed -i "/# >>> conda initialize >>>/,/# <<< conda initialize <<</d" /home/$USER_ID/.bashrc
+# 기존 유저 디렉토리의 /.bashrc에서 conda initialize 블록과 경고 주석을 제거
+sed -i \
+    -e "/# !!! Do NOT delete the conda initialize comments below\. !!!/d" \
+    -e "/# !!! Do NOT add anything inside the conda initialize block\. It will be removed on container restart\/update\. !!!/d" \
+    -e "/# >>> conda initialize >>>/,/# <<< conda initialize <<</d" \
+    /home/$USER_ID/.bashrc
 
 # /root/.bashrc에서 conda initialize 블록 추출해서 /home/$USER_ID/.bashrc에 추가
-sed -n "/# >>> conda initialize >>>/,/# <<< conda initialize <<</p" /root/.bashrc >> /home/$USER_ID/.bashrc
+{
+    echo "# !!! Do NOT delete the conda initialize comments below. !!!"
+    echo "# !!! Do NOT add anything inside the conda initialize block. It will be removed on container restart/update. !!!"
+    sed -n '/# >>> conda initialize >>>/,/# <<< conda initialize <<</p' /root/.bashrc
+} >> /home/$USER_ID/.bashrc
 
 fi
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #28 
 
## 🌱 작업 사항
- 기존 사용자의 컨테이너 변경 시 conda initialize 블록이 `~/.bashrc`에 반영되지 않아, `/root/.bashrc`에서 해당 블록을 복사해 오도록 수정
- `~/.bashrc` 내 conda initialize 블록을 수정하지 말라는 경고 주석 추가

## 🌱 참고 사항
- `entrypoint.sh`는 컨테이너 재시작 시에도 실행되므로, 기존 사용자의 새 컨테이너를 생성하는 경우 뿐만 아니라 컨테이너 재시작 시에도 conda initialize 블록이 삭제되었다가 다시 작성됨
- 테스트는 ~/.bashrc의 conda initialize 블록 내부를 수정한 뒤 컨테이너를 재시작했으며, 수정된 `entrypoint.sh`가 실행되면서 `~/.bashrc`의 conda initialize 블록이 초기화된 것을 확인함